### PR TITLE
feat: add dividends calendar endpoint

### DIFF
--- a/TODOS.md
+++ b/TODOS.md
@@ -1,0 +1,8 @@
+# TODOS
+
+## Dividends Company endpoint
+- **What:** Add `GetDividends(symbol, limit)` for `/stable/dividends` — historical
+  dividends for a single company.
+- **Why:** Natural companion to the Dividends Calendar; returns the identical record.
+- **Reuse:** Reuses `model.GetDividendsCalendarResponse` — no new response struct.
+- **Status:** Deferred from the dividends-calendar PR (scoped to calendar only).

--- a/market/analysis.go
+++ b/market/analysis.go
@@ -2,7 +2,7 @@ package market
 
 import (
 	"context"
-	"fmt"
+	"errors"
 	"net/http"
 
 	"go.tradeforge.dev/fmp/client/rest"
@@ -24,7 +24,7 @@ func (ac *AnalysisClient) GetAdvancedDCF(ctx context.Context, params *model.GetA
 		return nil, err
 	}
 	if len(res) == 0 {
-		return nil, fmt.Errorf("expected non-empty response, got 0 results")
+		return nil, errors.New("expected non-empty response, got 0 results")
 	}
 	return res, nil
 }

--- a/market/event.go
+++ b/market/event.go
@@ -9,8 +9,9 @@ import (
 )
 
 const (
-	GetEarningsCalendarPath = "/stable/earnings-calendar"
-	GetInsiderTradesPath    = "/stable/insider-trading/latest"
+	GetEarningsCalendarPath  = "/stable/earnings-calendar"
+	GetDividendsCalendarPath = "/stable/dividends-calendar"
+	GetInsiderTradesPath     = "/stable/insider-trading/latest"
 )
 
 type EventClient struct {
@@ -26,5 +27,11 @@ func (ec *EventClient) GetInsiderTrades(ctx context.Context, params model.GetIns
 func (ec *EventClient) GetEarningsCalendar(ctx context.Context, params *model.GetEarningsCalendarParams, opts ...model.RequestOption) ([]model.GetEarningsCalendarResponse, error) {
 	var res []model.GetEarningsCalendarResponse
 	_, err := ec.Call(ctx, http.MethodGet, GetEarningsCalendarPath, params, &res, opts...)
+	return res, err
+}
+
+func (ec *EventClient) GetDividendsCalendar(ctx context.Context, params *model.GetDividendsCalendarParams, opts ...model.RequestOption) ([]model.GetDividendsCalendarResponse, error) {
+	var res []model.GetDividendsCalendarResponse
+	_, err := ec.Call(ctx, http.MethodGet, GetDividendsCalendarPath, params, &res, opts...)
 	return res, err
 }

--- a/market/event_test.go
+++ b/market/event_test.go
@@ -40,8 +40,27 @@ func TestGetEarningsCalendar(t *testing.T) {
 	require.NoError(t, err)
 	require.NotEmpty(t, res)
 
-	for _, e := range res[:5] {
+	for _, e := range res {
 		assert.NotEmpty(t, e.Symbol)
 		assert.NotEmpty(t, string(e.Date))
+	}
+}
+
+func TestGetDividendsCalendar(t *testing.T) {
+	client := newTestHTTPClient(t)
+	ctx := context.Background()
+
+	since := types.Date("2025-01-06")
+	until := types.Date("2025-01-10")
+	res, err := client.GetDividendsCalendar(ctx, &model.GetDividendsCalendarParams{
+		Since: &since,
+		Until: &until,
+	})
+	require.NoError(t, err)
+	require.NotEmpty(t, res)
+
+	for _, d := range res {
+		assert.NotEmpty(t, d.Symbol)
+		assert.NotEmpty(t, string(d.Date))
 	}
 }

--- a/model/disclosure.go
+++ b/model/disclosure.go
@@ -89,7 +89,7 @@ func (r *FinancialDisclosureRangeAmount) UnmarshalJSON(data []byte) error {
 		valStr := parts[0]
 		valDec, err := decimal.NewFromString(valStr)
 		if err != nil {
-			return nil
+			return nil //nolint:nilerr // non-numeric amounts are tolerated, not unmarshalling errors
 		}
 		r.Min = valDec
 		r.Max = valDec
@@ -103,11 +103,11 @@ func (r *FinancialDisclosureRangeAmount) UnmarshalJSON(data []byte) error {
 	maxStr := parts[1]
 	minDec, err := decimal.NewFromString(minStr)
 	if err != nil {
-		return nil
+		return nil //nolint:nilerr // non-numeric amounts are tolerated, not unmarshalling errors
 	}
 	maxDec, err := decimal.NewFromString(maxStr)
 	if err != nil {
-		return nil
+		return nil //nolint:nilerr // non-numeric amounts are tolerated, not unmarshalling errors
 	}
 	r.Min = minDec
 	r.Max = maxDec

--- a/model/dividend.go
+++ b/model/dividend.go
@@ -1,0 +1,24 @@
+package model
+
+import (
+	"github.com/shopspring/decimal"
+
+	"go.tradeforge.dev/fmp/pkg/types"
+)
+
+type GetDividendsCalendarParams struct {
+	Since *types.Date `query:"from"`
+	Until *types.Date `query:"to"`
+}
+
+type GetDividendsCalendarResponse struct {
+	Symbol          string                    `json:"symbol"`
+	Date            types.Date                `json:"date"`
+	RecordDate      types.EmptyOr[types.Date] `json:"recordDate"`
+	PaymentDate     types.EmptyOr[types.Date] `json:"paymentDate"`
+	DeclarationDate types.EmptyOr[types.Date] `json:"declarationDate"`
+	AdjDividend     decimal.Decimal           `json:"adjDividend"`
+	Dividend        decimal.Decimal           `json:"dividend"`
+	Yield           decimal.Decimal           `json:"yield"`
+	Frequency       string                    `json:"frequency"`
+}

--- a/model/dividend_test.go
+++ b/model/dividend_test.go
@@ -1,0 +1,42 @@
+package model
+
+import (
+	_ "embed"
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"go.tradeforge.dev/fmp/pkg/types"
+)
+
+//go:embed fixtures/dividends_calendar.json
+var rawDividendsCalendar string
+
+func TestGetDividendsCalendarResponse_UnmarshalJSON(t *testing.T) {
+	var dividends []GetDividendsCalendarResponse
+	err := json.Unmarshal([]byte(rawDividendsCalendar), &dividends)
+	require.NoError(t, err)
+	require.Len(t, dividends, 3)
+
+	for _, d := range dividends {
+		assert.NotEmpty(t, d.Symbol)
+		assert.NotEmpty(t, string(d.Date))
+	}
+
+	// Fully-populated record: the secondary dates decode to present values.
+	full := dividends[0]
+	assert.False(t, full.RecordDate.IsEmpty())
+	assert.False(t, full.PaymentDate.IsEmpty())
+	assert.False(t, full.DeclarationDate.IsEmpty())
+	require.NotNil(t, full.RecordDate.Value())
+	assert.Equal(t, types.Date("2025-02-10"), *full.RecordDate.Value())
+
+	// Record with empty "" secondary dates: EmptyOr decodes them as empty
+	// instead of erroring on time.Parse of an empty string.
+	empty := dividends[1]
+	assert.True(t, empty.RecordDate.IsEmpty())
+	assert.True(t, empty.PaymentDate.IsEmpty())
+	assert.True(t, empty.DeclarationDate.IsEmpty())
+}

--- a/model/fixtures/dividends_calendar.json
+++ b/model/fixtures/dividends_calendar.json
@@ -1,0 +1,35 @@
+[
+  {
+    "symbol": "AAPL",
+    "date": "2025-02-10",
+    "recordDate": "2025-02-10",
+    "paymentDate": "2025-02-13",
+    "declarationDate": "2025-01-30",
+    "adjDividend": 0.25,
+    "dividend": 0.25,
+    "yield": 0.44,
+    "frequency": "Quarterly"
+  },
+  {
+    "symbol": "NEWCO",
+    "date": "2025-02-11",
+    "recordDate": "",
+    "paymentDate": "",
+    "declarationDate": "",
+    "adjDividend": 0.10,
+    "dividend": 0.10,
+    "yield": 1.2,
+    "frequency": ""
+  },
+  {
+    "symbol": "MSFT",
+    "date": "2025-02-20",
+    "recordDate": "2025-02-20",
+    "paymentDate": "2025-03-13",
+    "declarationDate": "2024-12-03",
+    "adjDividend": 0.83,
+    "dividend": 0.83,
+    "yield": 0.79,
+    "frequency": "Quarterly"
+  }
+]


### PR DESCRIPTION
## Summary

Adds `GetDividendsCalendar` on `EventClient` for FMP's `/stable/dividends-calendar` endpoint — dividend events (ex-dividend, record, payment, declaration dates plus amount, yield, frequency) across all companies for an optional `from`/`to` date range.

- **`model/dividend.go`** — `GetDividendsCalendarParams` + `GetDividendsCalendarResponse`. Optional `recordDate`/`paymentDate`/`declarationDate` use `types.EmptyOr[types.Date]` because FMP returns them as empty strings for some records, which plain `types.Date` rejects on parse.
- **`market/event.go`** — `GetDividendsCalendarPath` constant + `GetDividendsCalendar` method. No `fmp.go` wiring change — `EventClient` is already composed into `HTTPClient`.
- **`market/event_test.go`** — `TestGetDividendsCalendar` integration test; also fixes a latent `res[:5]` slice-bounds panic in `TestGetEarningsCalendar`.
- **`TODOS.md`** — tracks the deferred per-company `/stable/dividends` endpoint, which reuses the same response type.

Mirrors the existing `GetEarningsCalendar` pattern.

### Drive-by: CI lint fix (commit 5fd2062)

`golangci-lint` was already red on `main` before this branch (unrelated to the dividends calendar). Fixed here so PR #9 lands green:
- `model/disclosure.go` — 3x `nilerr`: the `return nil` on a decimal parse failure is intentional (non-numeric disclosure amounts are tolerated, see `70a7c9f`); annotated with `//nolint:nilerr` + reason.
- `market/analysis.go` — `perfsprint`: `fmt.Errorf` with no format args replaced with `errors.New`.

## Test Coverage

- `model/dividend_test.go` — offline unmarshal test (no API key needed). Exercises both `EmptyOr` branches: a fully-populated record and one with empty `""` secondary dates.
- `TestGetDividendsCalendar` — integration test, skips cleanly without `FMP_API_KEY`.
- All new code paths covered. `go build`, `go vet`, `gofmt`, `golangci-lint`, and `go test ./...` all pass.

## Pre-Landing Review

No issues. Reviewed by `/plan-eng-review` this session (architecture, code quality, tests, performance — all clean) and a focused pre-landing pass on the diff: no SQL, no concurrency, no LLM/auth surface; the one real risk (FMP empty-string dates) is handled by `EmptyOr`.

## Plan Completion

All 6 plan deliverables shipped: `model/dividend.go`, `event.go` method + constant, `model/fixtures/dividends_calendar.json`, `model/dividend_test.go`, `event_test.go` test, `TODOS.md`.

## Test plan

- [x] `go build ./...`, `go vet ./...`, `gofmt`, `golangci-lint` — clean
- [x] `go test ./...` — all packages pass
- [x] Live endpoint check — `TestGetDividendsCalendar` and `TestGetEarningsCalendar` pass against the real FMP API

Release: this module versions via git tags (latest `v0.15.3`) — tag a release after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)